### PR TITLE
Implement “M” Standard Extension for Integer Multiplication and Division

### DIFF
--- a/src/executer.rs
+++ b/src/executer.rs
@@ -375,28 +375,77 @@ pub fn exec(
             }
         }
         Instruction::MUL(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            // Rust panics if the result of the multiplication overflows. The RISC-V spec doesn't care and just stores the low 32 bits
+            // For this reason, the multiplication is done on 64-bit numbers and then typecasted.
+            let _rs1_64 = _rs1 as u64;
+            let _rs2_64 = _rs2 as u64;
+            register_file.write(rdindex, (_rs1_64* _rs2_64) as u32);
         }
         Instruction::MULH(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            let result: i64 = (i64::from(_rs1)) * (i64::from(_rs2));
+            let high_bytes: u32 = (result >> 32) as u32;
+            register_file.write(rdindex, high_bytes);
         }
         Instruction::MULHSU(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            let result = i64::from(_rs1).wrapping_mul(i64::from(_rs2));
+            let high_bytes: u32 = (result >> 32) as u32;
+            register_file.write(rdindex, high_bytes);
         }
         Instruction::MULHU(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            let result: u64 = (_rs1 as u64 * _rs2 as u64);
+            let high_bytes: u32 = (result >> 32) as u32;
+            register_file.write(rdindex, high_bytes);
         }
         Instruction::DIV(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            if (_rs2 == 0) {
+                // The spec defines that -1 should be stored. In 32-bit two's complement, u32::MAX is -1
+                register_file.write(rdindex, u32::MAX);
+            }
+            else {
+                let result: i32 = (_rs1 / _rs2) as i32;
+                register_file.write(rdindex, result as u32);
+            } 
         }
         Instruction::DIVU(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            if (_rs2 == 0) {
+                register_file.write(rdindex, u32::MAX);
+            }
+            else {
+                register_file.write(rdindex, _rs1 / _rs2);
+            }
         }
         Instruction::REM(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            if (_rs2 == 0) {
+                register_file.write(rdindex, _rs1);
+            }
+            else {
+                let result: i32 = (_rs1 % _rs2) as i32;
+                register_file.write(rdindex, result as u32);
+            }
         }
         Instruction::REMU(rdindex, rs1index, rs2index) => {
-            todo!();
+            let _rs1: RS1value = register_file.read(rs1index);
+            let _rs2: RS2value = register_file.read(rs2index);
+            if (_rs2 == 0) {
+                register_file.write(rdindex, _rs1);
+            }
+            else {
+                register_file.write(rdindex, _rs1 % _rs2);
+            }
         }
     }
     register_file.pc += 4;

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,8 @@ fn main() -> anyhow::Result<()> {
     if args.headless {
         loop {
             let inst = decode(memory.read_word(register_file.pc as usize)).unwrap();
-            if !exec(&mut register_file, &mut memory, &inst, true, false) {
+
+            if !exec(&mut register_file, &mut memory, &inst, true, true) {
                 break;
             }
         }

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -9,18 +9,18 @@ banner() {
 }
 
 banner "Build tests"
-make -C src/isa XLEN=${XLEN} rv32um
+make -C src/isa XLEN=${XLEN} rv32ui rv32um
 
 banner "Run tests"
 
 exit=0
-for file in src/isa/rv32um-p-*; do
+for file in src/isa/rv32ui-p-* src/isa/rv32um-p-*; do
 	[ -f "${file}" -a -x "${file}" ] || continue
 
 	name=${file##*/}
 	printf "Running test case '%s': " "$name"
 
-	if [ "${name}" = rv32um-p-fence_i ]; then
+	if [ "${name}" = rv32ui-p-fence_i ]; then
 		printf "SKIP\n"
 		continue
 	fi

--- a/tests/build.sh
+++ b/tests/build.sh
@@ -2,25 +2,25 @@
 set -e
 
 export XLEN=32
-export RISCV_GCC_OPTS="-I$(pwd)/include -I$(pwd)/src/env -march=rv32i_zifencei -mabi=ilp32 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles"
+export RISCV_GCC_OPTS="-I$(pwd)/include -I$(pwd)/src/env -march=rv32im_zifencei -mabi=ilp32 -static -mcmodel=medany -fvisibility=hidden -nostdlib -nostartfiles"
 
 banner() {
 	printf "##\n# %s\n##\n\n" "${1}"
 }
 
 banner "Build tests"
-make -C src/isa XLEN=${XLEN} rv32ui
+make -C src/isa XLEN=${XLEN} rv32um
 
 banner "Run tests"
 
 exit=0
-for file in src/isa/rv32ui-p-*; do
+for file in src/isa/rv32um-p-*; do
 	[ -f "${file}" -a -x "${file}" ] || continue
 
 	name=${file##*/}
 	printf "Running test case '%s': " "$name"
 
-	if [ "${name}" = rv32ui-p-fence_i ]; then
+	if [ "${name}" = rv32um-p-fence_i ]; then
 		printf "SKIP\n"
 		continue
 	fi


### PR DESCRIPTION
This Pull Request implements the “M” Standard Extension for Integer Multiplication and Division. The build scripts have also been altered to use an arch that supports the instructions, and also the test script now builds and runs the `um` tests instead of the `ui` tests. Additionally, `m_enabled` is set to `true` in the main source file in order to be able to actually run the instructions from this extension.