### PR TITLE
♻️ : Split periph.rs into components and behavior

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,6 @@ mod ui;
 use ui::tui_loop;
 
 mod periph;
-use crate::periph::{Uart, UartBuffered, UartTty};
 
 mod instructions;
 
@@ -79,9 +78,9 @@ fn main() {
 
     // Not headless? Start TUI!
     if !args.headless {
-        let (tx, tui_reader): (mpsc::Sender<char>, mpsc::Receiver<char>) = mpsc::channel();
-        let (tui_writer, rx): (mpsc::Sender<char>, mpsc::Receiver<char>) = mpsc::channel();
-        let mut buffered = Uart::default(UartBuffered::new(rx, tx));
+        let (tx, tui_reader): (mpsc::Sender<u8>, mpsc::Receiver<u8>) = mpsc::channel();
+        let (tui_writer, rx): (mpsc::Sender<u8>, mpsc::Receiver<u8>) = mpsc::channel();
+        let mut buffered = periph::new_buffered_uart(rx, tx);
         let mut cpu = {
             if args.bin {
                 let entry = usize_from_str(&args.entryaddress);
@@ -97,7 +96,7 @@ fn main() {
         return;
     }
 
-    let mut tty = Uart::default(UartTty::new());
+    let mut tty = periph::new_stdio_uart();
     let mut cpu = {
         if args.bin {
             let entry = usize_from_str(&args.entryaddress);

--- a/src/periph/backend.rs
+++ b/src/periph/backend.rs
@@ -1,0 +1,76 @@
+use std::io;
+use std::io::Read;
+use std::sync::mpsc;
+
+use crate::periph::peekable_reader::PeekableReader;
+use crate::periph::PeripheralBackend;
+
+/// A backend that reads from stdin and writes to stdout
+pub struct BackendTty {
+    peek_reader: PeekableReader<u8>,
+}
+
+impl BackendTty {
+    pub fn new() -> Self {
+        // setup a PeekableReader that fetches data from stdin
+        let reader = PeekableReader::new(|| {
+            let mut buffer: [u8; 1] = [0];
+            io::stdin().read_exact(&mut buffer).unwrap();
+            buffer[0]
+        });
+        BackendTty {
+            peek_reader: reader,
+        }
+    }
+}
+
+impl PeripheralBackend for BackendTty {
+    fn has_data(&self) -> bool {
+        self.peek_reader.has_data()
+    }
+    fn read_cb(&self) -> Option<u8> {
+        if let Some(val) = self.peek_reader.try_recv() {
+            return Some(val);
+        }
+        None
+    }
+
+    // We can directly print in order to write to stdout
+    fn write_cb(&self, value: u8) {
+        print!("{:}", value as char);
+    }
+}
+
+/// A backend that reads from a given `mpsc::Receiver` and writes to a given `mpsc::Sender`
+pub struct BackendBuffered<T> {
+    writer: mpsc::Sender<T>,
+    peek_reader: PeekableReader<T>,
+}
+
+impl<T: Send + 'static> BackendBuffered<T> {
+    pub fn new(input: mpsc::Receiver<T>, output: mpsc::Sender<T>) -> Self {
+        let reader = PeekableReader::new(move || input.recv().unwrap());
+        BackendBuffered {
+            writer: output,
+            peek_reader: reader,
+        }
+    }
+}
+
+impl<T: Send + 'static + From<u8>> PeripheralBackend for BackendBuffered<T>
+where
+    u8: From<T>,
+{
+    fn has_data(&self) -> bool {
+        self.peek_reader.has_data()
+    }
+    fn read_cb(&self) -> Option<u8> {
+        if let Some(val) = self.peek_reader.try_recv() {
+            return Some(u8::from(val));
+        }
+        None
+    }
+    fn write_cb(&self, value: u8) {
+        self.writer.send(value.into()).unwrap();
+    }
+}

--- a/src/periph/mod.rs
+++ b/src/periph/mod.rs
@@ -1,0 +1,32 @@
+//! Emulation of hardware peripherals is scoped for this file.
+//! Currently, only memory mapped peripherals are available via `trait MmapPeripheral`.
+use std::sync::mpsc;
+
+mod backend;
+mod peekable_reader;
+mod uart;
+
+use backend::{BackendBuffered, BackendTty};
+use uart::Uart;
+
+pub trait MmapPeripheral {
+    fn read(&self, offset: usize) -> u8;
+    fn write(&mut self, offset: usize, value: u8);
+}
+
+trait PeripheralBackend {
+    fn has_data(&self) -> bool;
+    fn read_cb(&self) -> Option<u8>;
+    fn write_cb(&self, value: u8);
+}
+
+pub fn new_buffered_uart(
+    input: mpsc::Receiver<u8>,
+    output: mpsc::Sender<u8>,
+) -> impl MmapPeripheral {
+    Uart::default(BackendBuffered::new(input, output))
+}
+
+pub fn new_stdio_uart() -> impl MmapPeripheral {
+    Uart::default(BackendTty::new())
+}

--- a/src/periph/peekable_reader.rs
+++ b/src/periph/peekable_reader.rs
@@ -1,0 +1,69 @@
+use std::sync::mpsc::{self, TryRecvError};
+use std::sync::{Arc, Mutex};
+use std::thread;
+
+/// A wrapper for `mpsc::Receiver` that can be queried if there is data pending.
+pub struct PeekableReader<T> {
+    data_available: Arc<Mutex<Option<T>>>,
+    reader: mpsc::Receiver<T>,
+}
+
+impl<T: Send + 'static> PeekableReader<T> {
+    /// Creates a new `PeekableReader`
+    /// Argument `f` function / closure is called repeatedly
+    /// Should yield a new value everytime that is send to the "receiver"
+    /// `f` is allowed to block infinitly
+    pub fn new<F: Fn() -> T + Send + 'static>(f: F) -> Self {
+        let (tx, rx): (mpsc::Sender<T>, mpsc::Receiver<T>) = mpsc::channel();
+        let data_mux = Arc::new(Mutex::new(None));
+        let data_mux_clone = data_mux.clone();
+        thread::spawn(move || loop {
+            let data = f();
+            let mut data_available = data_mux_clone.lock().unwrap();
+            if (*data_available).is_none() {
+                *data_available = Some(data);
+            } else {
+                tx.send(data).unwrap();
+            }
+        });
+        Self {
+            data_available: data_mux,
+            reader: rx,
+        }
+    }
+
+    /// Returns true if new data is available
+    /// Returns false if not.
+    pub fn has_data(&self) -> bool {
+        let mut data_available = self.data_available.lock().unwrap();
+        if data_available.is_some() {
+            return true;
+        }
+        match self.reader.try_recv() {
+            Ok(val) => {
+                *data_available = Some(val);
+                true
+            }
+            Err(err) => match err {
+                TryRecvError::Empty => false,
+                TryRecvError::Disconnected => panic!(),
+            },
+        }
+    }
+
+    /// Equivalent to the `mpsc::Receiver::try_recv()`
+    /// This method will never block the caller in order to wait for data to become available.
+    pub fn try_recv(&self) -> Option<T> {
+        if let Some(value) = self.data_available.lock().unwrap().take() {
+            Some(value)
+        } else {
+            match self.reader.try_recv() {
+                Ok(value) => Some(value),
+                Err(err) => match err {
+                    TryRecvError::Empty => None,
+                    TryRecvError::Disconnected => panic!(),
+                },
+            }
+        }
+    }
+}

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -86,7 +86,7 @@ impl ViewState {
         &mut self,
         f: &mut Frame,
         cpu: &CPU<'_>,
-        uart_rx: &mpsc::Receiver<char>,
+        uart_rx: &mpsc::Receiver<u8>,
         show_help: bool,
         insert_mode: bool,
         user_input: &String,
@@ -168,7 +168,7 @@ impl ViewState {
             .title_alignment(Alignment::Left);
 
         if let Ok(msg) = uart_rx.try_recv() {
-            self.uart.push(msg);
+            self.uart.push(msg as char);
         }
         let text: &str = &self.uart;
         let text = Text::from(text);
@@ -227,8 +227,8 @@ fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
 
 pub fn tui_loop<'a>(
     cpu: &'a mut CPU<'a>,
-    uart_rx: &mpsc::Receiver<char>,
-    uart_tx: &mpsc::Sender<char>,
+    uart_rx: &mpsc::Receiver<u8>,
+    uart_tx: &mpsc::Sender<u8>,
 ) -> anyhow::Result<()> {
     enable_raw_mode()?;
     let stdout = io::stdout();
@@ -256,7 +256,7 @@ pub fn tui_loop<'a>(
                         KeyCode::Enter => {
                             user_input.push('\n');
                             for ch in user_input.chars() {
-                                uart_tx.send(ch)?;
+                                uart_tx.send(ch as u8)?;
                             }
                             user_input.clear();
                         }


### PR DESCRIPTION
This splits the periph.rs:

- Now clearly shows the interface to the rest of the emulator (`MmapPeripheral`)
- Uart now cleanly split into the hardware emulation and input/output stream called `PeripheralBackend`
- `PeripheralBackend` tries to be generic trait so it can be used with future not-uart hardware emulation
- `PeekableReader` introduced that wraps a `mpsc::Receiver` channel and makes it peekable